### PR TITLE
RFC/Array Slice

### DIFF
--- a/text/0000-arrayslice.md
+++ b/text/0000-arrayslice.md
@@ -40,9 +40,10 @@ This is a simpler and more naturally recursive implementation.
 
 The mechanics are pretty straightforward and would operate in a
 similar fashion to ranges.  As for ranges, the left-hand side is
-inclusive and the right-hand side exclusive.  Should the syntax for
-ranges change to allow different combinations of exclusivity, then we
-would update this operator accordingly.
+inclusive and the right-hand side exclusive (this follows Rust for
+example).  Should the syntax for ranges change to allow different
+combinations of exclusivity, then we would update this operator
+accordingly.
 
 # Terminology
 

--- a/text/0000-arrayslice.md
+++ b/text/0000-arrayslice.md
@@ -40,10 +40,19 @@ This is a simpler and more naturally recursive implementation.
 
 The mechanics are pretty straightforward and would operate in a
 similar fashion to ranges.  As for ranges, the left-hand side is
-inclusive and the right-hand side exclusive (this follows Rust for
-example).  Should the syntax for ranges change to allow different
-combinations of exclusivity, then we would update this operator
-accordingly.
+inclusive and the right-hand side exclusive (this follows Rust and
+Dafny for example).  Should the syntax for ranges change to allow
+different combinations of exclusivity, then we would update this
+operator accordingly.
+
+The operator would support three forms:
+
+   * `arr[s..e]` which returns the subarray from `s` upto (but not
+     including) `e`.
+
+   * `arr[s..]` is syntactic sugar for `arr[s..|arr|]`
+
+   * `arr[..e]` is syntactic sugar for `arr[0..e]`.
 
 # Terminology
 

--- a/text/0000-arrayslice.md
+++ b/text/0000-arrayslice.md
@@ -1,0 +1,57 @@
+- Feature Name: `array_slice`
+- Start Date: `27-05-22`
+- RFC PR: (leave this empty)
+
+# Summary
+
+The array slice is a useful operation found in many languages, and it
+would be good to add this to Whiley.
+
+# Motivation
+
+The array slice would be a useful addition to Whiley.  For example,
+consider the current implementation of `sum()`:
+
+```Whiley
+property sum(int[] items, int i) -> (int r):
+   if i < 0 || i >= |items|:
+      return 0
+   else:   
+      return items[i] + sum(items,i+1)
+```
+
+This is a bit cumbersome because of the need to use an index `i`.
+Note that, whilst the `std::array::slice()` exists, this is not a
+`property` and hence would be uninterpreted in this situation meaning
+some things would not verify.  A neat solution can be found using the
+array slice operator as follows:
+
+```Whiley
+property sum(int[] items) -> (int r):
+   if items == []:
+      return 0
+   else:
+      return items[0] + sum(items[1..])
+```
+
+This is a simpler and more naturally recursive implementation.
+
+# Technical Details
+
+The mechanics are pretty straightforward and would operate in a
+similar fashion to ranges.  As for ranges, the left-hand side is
+inclusive and the right-hand side exclusive.  Should the syntax for
+ranges change to allow different combinations of exclusivity, then we
+would update this operator accordingly.
+
+# Terminology
+
+None.
+
+# Drawbacks and Limitations
+
+N/A
+
+# Unresolved Issues
+
+N/A


### PR DESCRIPTION
This proposal is to add an array slice operator (e.g. `arr[0..5]`).

View the proposal [here](https://github.com/Whiley/RFCs/blob/4b0e5c0f7b05fc4854cee13e9b48de2f96600ddb/text/0000-arrayslice.md)